### PR TITLE
Don't send units if they don't exist

### DIFF
--- a/SunGather/exports/mqtt.py
+++ b/SunGather/exports/mqtt.py
@@ -91,7 +91,8 @@ class export_mqtt(object):
                     config_msg['unique_id'] = "inverter_" + self.cleanName(ha_sensor.get('name'))
                 config_msg['state_topic'] = self.mqtt_config['topic']
                 config_msg['value_template'] = "{{ value_json." + ha_sensor.get('register') + " }}"
-                config_msg['unit_of_measurement'] = inverter.getRegisterUnit(ha_sensor.get('register'))
+                if inverter.getRegisterUnit(ha_sensor.get('register')):
+                    config_msg['unit_of_measurement'] = inverter.getRegisterUnit(ha_sensor.get('register'))
                 if ha_sensor.get('dev_class'):
                     config_msg['device_class'] = ha_sensor.get('dev_class')
                 if ha_sensor.get('state_class'):


### PR DESCRIPTION
When a unit_of_measurement exists, Home Assistant assumes it's an integer and tries to graph it. Even if no unit_of_measurement are given. By not adding them, Home Assistant takes the value as discrete and visualizes it accordingly.

It's only relevant for few registers. I am using it for "work_state_1".  What the broken graph in Home Assistant looks like at the moment: https://imgur.com/JB67fax. After removing units_of_measurement: https://imgur.com/6rYNAAA and combined with other data: https://imgur.com/1TzAqFd. work_state_1 shows not only "Run" and "Standby", but "Starting" and "Degraded Run" as well which is important for monitoring.