### PR TITLE
renames state_daily_pv_generation back to daily_pv_generation 

### DIFF
--- a/SunGather/registers-sungrow.yaml
+++ b/SunGather/registers-sungrow.yaml
@@ -1155,7 +1155,7 @@ registers:
       datatype: "U16"
       mask: 128
       models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "state_daily_pv_generation"
+    - name: "daily_pv_generation"
       level: 2
       address: 13002
       datatype: "U16"


### PR DESCRIPTION
Was changed by mistake in #59. I should have seen this before :-(