### PR TITLE
Add prometheus metrics exporter

### DIFF
--- a/SunGather/config-example.yaml
+++ b/SunGather/config-example.yaml
@@ -154,3 +154,7 @@ exports:
 #       register:
 #     - name: "m1"                          # Text Message 1 - Donation Only
 #       register:
+
+  - name: prometheus
+    enabled: True                          # [Optional] Default is False
+    # port: 8000                           # [Optional] Default 8000

--- a/SunGather/exports/prometheus.py
+++ b/SunGather/exports/prometheus.py
@@ -1,0 +1,47 @@
+from prometheus_client import start_http_server, Gauge, Enum, Info, REGISTRY, PROCESS_COLLECTOR, PLATFORM_COLLECTOR
+import logging
+
+# Ignore Python related metrics
+REGISTRY.unregister(PROCESS_COLLECTOR)
+REGISTRY.unregister(PLATFORM_COLLECTOR)
+REGISTRY.unregister(REGISTRY._names_to_collectors['python_gc_objects_collected_total'])
+
+class export_prometheus(object):
+    def configure(self, config, inverter):
+        try:
+            self.device_type_code = Info('inverter_device_type_code', 'Device Type Code')
+            self.run_state = Enum("inverter_run_state", "Run State", states=["ON", "OFF"])
+            self.daily_power_yields = Gauge("inverter_daily_power_yield_watt_hours_total", "Daily Power Yields")
+            self.total_power_yields = Gauge("inverter_total_power_yield_watt_hours_total", "Total Power Yields")
+            self.internal_temperature = Gauge("inverter_internal_temperature_celsius", "Internal Temperature")
+            self.phase_a_voltage = Gauge("inverter_phase_a_voltage_volts", "Phase A Voltage")
+            self.total_active_power = Gauge("inverter_active_power_watts_total", "Total Active Power")
+            self.work_state = Info('inverter_work_state', 'Work State')
+            self.meter_power = Gauge("inverter_meter_power_watts_total", "Meter Power")
+
+            start_http_server(config.get('port', 8000))
+        except Exception as err:
+            logging.error(f"Prometheus-Export: Error: {err}")
+            return False
+        return True
+
+
+    def publish(self, inverter):
+        try:
+            latest_scrape = inverter.latest_scrape
+
+            self.device_type_code.info({'device_type_code': latest_scrape['device_type_code']})
+            self.run_state.state(latest_scrape['run_state'])
+            self.daily_power_yields.set(latest_scrape['daily_power_yields'] * 1000)
+            self.total_power_yields.set(latest_scrape['total_power_yields'] * 1000)
+            self.internal_temperature.set(latest_scrape['internal_temperature'])
+            self.phase_a_voltage.set(latest_scrape['phase_a_voltage'])
+            self.total_active_power.set(latest_scrape['total_active_power'])
+            self.work_state.info({'work_state': latest_scrape['work_state_1']})
+            self.meter_power.set(latest_scrape['meter_power'])
+
+            logging.debug(f"Prometheus-Published")
+        except Exception as err:
+            logging.error(f"Prometheus-Publishing: Error: {err}")
+            return False
+        return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pymodbus>=2.5.3
 SungrowModbusTcpClient>=0.1.5
 SungrowModbusWebClient>=0.3.2
 influxdb-client>=1.24.0
+prometheus-client==0.14.1


### PR DESCRIPTION
Opening an early Draft PR to get some feedback around a Prometheus exporter using [Prometheus Python Client](https://github.com/prometheus/client_python)

Labels are following the [Metric and Label naming guide ](https://prometheus.io/docs/practices/naming/)

The metrics output looks like below.

```
# HELP inverter_device_type_code_info Device Type Code
# TYPE inverter_device_type_code_info gauge
inverter_device_type_code_info{device_type_code="SG5K-D"} 1.0
# HELP inverter_run_state Run State
# TYPE inverter_run_state gauge
inverter_run_state{inverter_run_state="ON"} 1.0
inverter_run_state{inverter_run_state="OFF"} 0.0
# HELP inverter_daily_power_yield_watt_hours_total Daily Power Yields
# TYPE inverter_daily_power_yield_watt_hours_total gauge
inverter_daily_power_yield_watt_hours_total 1800.0
# HELP inverter_total_power_yield_watt_hours_total Total Power Yields
# TYPE inverter_total_power_yield_watt_hours_total gauge
inverter_total_power_yield_watt_hours_total 70100.0
# HELP inverter_internal_temperature_celsius Internal Temperature
# TYPE inverter_internal_temperature_celsius gauge
inverter_internal_temperature_celsius 34.0
# HELP inverter_phase_a_voltage_volts Phase A Voltage
# TYPE inverter_phase_a_voltage_volts gauge
inverter_phase_a_voltage_volts 235.2
# HELP inverter_active_power_watts_total Total Active Power
# TYPE inverter_active_power_watts_total gauge
inverter_active_power_watts_total 1482.0
# HELP inverter_work_state_info Work State
# TYPE inverter_work_state_info gauge
inverter_work_state_info{work_state="Run"} 1.0
# HELP inverter_meter_power_watts_total Meter Power
# TYPE inverter_meter_power_watts_total gauge
inverter_meter_power_watts_total -677.0
```

I haven't added all the metrics yet but wondering if this is ok or do I need to maybe push the configuration in to the `config.yaml` ?