### PR TITLE
Workaround for string type values

### DIFF
--- a/SunGather/exports/influxdb.py
+++ b/SunGather/exports/influxdb.py
@@ -60,9 +60,10 @@ class export_influxdb(object):
             if not inverter.validateLatestScrape(measurement['register']):
                 logging.error(f"InfluxDB: Skipped collecting data,  {measurement['register']} missing from last scrape")
                 return False
-            sequence.append(f"{measurement['point']},inverter={inverter.getInverterModel(True)} {measurement['register']}={inverter.getRegisterValue(measurement['register'])}")
-        logging.debug(f'InfluxDB: Sequence; {sequence}')
-
+            if type(inverter.getRegisterValue(measurement['register'])) is str:
+                sequence.append(influxdb_client.Point(measurement['point']).tag("inverter", inverter.getInverterModel(True)).field(measurement['register'], inverter.getRegisterValue(measurement['register'])))
+            else:
+                sequence.append(influxdb_client.Point(measurement['point']).tag("inverter", inverter.getInverterModel(True)).field(measurement['register'], float(inverter.getRegisterValue(measurement['register']))))
         try:
             self.write_api.write(self.influxdb_config['bucket'], self.client.org, sequence)
         except Exception as err:


### PR DESCRIPTION
Workaround for string type values and changing from line protocol to more modern point protocol. This lets the library decide which transfer protocol to use.

The alternative with the existing line protocol would be the following patch, which just quotes strings:
```
diff --git "a/SunGather/exports/influxdb.py" "b/SunGather/exports/influxdb.py"
index c0028c2..1007f81 100644
--- "a/SunGather/exports/influxdb.py"
+++ "b/SunGather/exports/influxdb.py"
@@ -60,7 +60,10 @@ class export_influxdb(object):
             if not inverter.validateLatestScrape(measurement['register']):
                 logging.error(f"InfluxDB: Skipped collecting data,  {measurement['register']} missing from last scrape")
                 return False
-            sequence.append(f"{measurement['point']},inverter={inverter.getInverterModel(True)} {measurement['register']}={inverter.getRegisterValue(measurement['register'])}")
+            if type(inverter.getRegisterValue(measurement['register'])) is str:
+                sequence.append(f"{measurement['point']},inverter={inverter.getInverterModel(True)} {measurement['register']}=\"{inverter.getRegisterValue(measurement['register'])}\"")
+            else:
+                sequence.append(f"{measurement['point']},inverter={inverter.getInverterModel(True)} {measurement['register']}={inverter.getRegisterValue(measurement['register'])}")
         logging.debug(f'InfluxDB: Sequence; {sequence}')
 
         try:

```