### PR TITLE
fix influxdb init

### DIFF
--- a/SunGather/exports/influxdb.py
+++ b/SunGather/exports/influxdb.py
@@ -45,7 +45,7 @@ class export_influxdb(object):
         for measurement in config.get('measurements'):
             if not inverter.validateRegister(measurement['register']):
                 logging.error(f"InfluxDB: Configured to use {measurement['register']} but not configured to scrape this register")
-                return False
+                continue
             self.influxdb_measurements.append(measurement)
 
         self.write_api = self.client.write_api(write_options=SYNCHRONOUS)


### PR DESCRIPTION
at the moment influxdb initialization fails when the config contains registers which are not scraped, no exports are done than.

this should not happen - the warning in the log should be enough. experts should be done even if some registers are not scraped (as it works for mqtt)