### PR TITLE
registers-sungrow.yaml: Add SH5.0RT that registers as 0xE0C

### DIFF
--- a/SunGather/registers-sungrow.yaml
+++ b/SunGather/registers-sungrow.yaml
@@ -193,6 +193,8 @@ registers:
           value: "SH6.0RT"
         - response: 0xE00
           value: "SH5.0RT"
+        - response: 0xE0C
+          value: "SH5.0RT"
       # G2 Inverters
         - response: 0x122
           value: "SG3K-D"


### PR DESCRIPTION
The latest protocol spec I found did not have this as a registered unit however seems to be the ID that newer units at least in germany use. All registers from level2 are working as is from the existing SH5.0RT so there seems to be no difference between the two models