### PR TITLE
example config: fix state_class for daily grid ex/import

### DIFF
--- a/SunGather/config-example.yaml
+++ b/SunGather/config-example.yaml
@@ -78,7 +78,7 @@ exports:
         sensor_type: sensor
         register: daily_export_to_grid
         device_class: energy
-        state_class: total_increasing
+        state_class: total
         icon: "mdi:transmission-tower-export"
         value_template: "{{ value_json.daily_export_to_grid | round(2) }}"
         last_reset_value_template: "{{ value_json.last_reset }}"
@@ -86,7 +86,7 @@ exports:
         sensor_type: sensor
         register: daily_import_from_grid
         device_class: energy
-        state_class: total_increasing
+        state_class: total
         icon: "mdi:transmission-tower-import"
         value_template: "{{ value_json.daily_import_from_grid | round(2) }}"
         last_reset_value_template: "{{ value_json.last_reset }}"


### PR DESCRIPTION
Solves the following log issue with HA:

```
WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.sh8_0rt_daily_import_from_grid (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) with state_class total_increasing has set last_reset. Setting last_reset for entities with state_class other than 'total' is not supported. Please update your configuration if state_class is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.sh8_0rt_daily_export_to_grid (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) with state_class total_increasing has set last_reset. Setting last_reset for entities with state_class other than 'total' is not supported. Please update your configuration if state_class is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
```