### PR TITLE
fix prometheus metrics

### DIFF
--- a/SunGather/exports/webserver.py
+++ b/SunGather/exports/webserver.py
@@ -20,6 +20,7 @@ class export_webserver(object):
             self.t = Thread(target=self.webServer.serve_forever)
             self.t.daemon = True    # Make it a deamon, so if main loop ends the webserver dies
             self.t.start()
+            self.metrics_prefix = config.get("prefix", "")
             logging.info(f"Webserver: Configured")
         except Exception as err:
             logging.error(f"Webserver: Error: {err}")
@@ -48,6 +49,15 @@ class export_webserver(object):
 
     def publish(self, inverter):
         json_array={"registers":{}, "client_config":{}, "inverter_config":{}}
+        metrics_common = ""
+        model = inverter.inverter_config.get("model", None)
+        if model is not None:
+            metrics_common += f"model=\"{model}\""
+        serial = inverter.inverter_config.get("serial_number", None)
+        if serial is not None:
+            if model is None:
+                metrics_common += ", "
+            metrics_common += f"serial=\"{serial}\""
         metrics_body = ""
         main_body = f"""
             <h3>SunGather v{__version__}</h3></p>
@@ -57,7 +67,14 @@ class export_webserver(object):
         main_body += "<table><th>Address</th><tr><th>Register</th><th>Value</th></tr>"
         for register, value in inverter.latest_scrape.items():
             main_body += f"<tr><td>{str(inverter.getRegisterAddress(register))}</td><td>{str(register)}</td><td>{str(value)} {str(inverter.getRegisterUnit(register))}</td></tr>"
-            metrics_body += f"{str(register)}{{address=\"{str(inverter.getRegisterAddress(register))}\", unit=\"{str(inverter.getRegisterUnit(register))}\"}} {str(value)}\n"
+            # desc = inverter.getRegisterDescription(register)
+            # if desc != "":
+            #     metrics_body += f"# HELP {str(help)}\n"
+            # metrics_body += f"# TYPE {self.metrics_prefix}{str(register)} {str(inverter.getRegisterType(register))}\n"
+            if isinstance(value, int) or isinstance(value, float):
+                metrics_body += f"{self.metrics_prefix}{str(register)}{{{metrics_common}}} {str(value)}\n"
+            else:
+                logging.debug(f"metrics: register {str(register)} of type {type(value)} ignored -> {value}")
             json_array["registers"][str(inverter.getRegisterAddress(register))]={"register": str(register), "value":str(value), "unit": str(inverter.getRegisterUnit(register))}
         main_body += f"</table><p>Total {len(inverter.latest_scrape)} registers"
 
@@ -79,19 +96,19 @@ class MyServer(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path.startswith('/metrics'):
             self.send_response(200)
-            self.send_header("Content-type", "text/plain")
+            self.send_header("Content-type", "text/plain; charset=utf-8")
             self.end_headers()
             self.wfile.write(bytes(export_webserver.metrics, "utf-8"))
         elif self.path.startswith('/config'):
             self.send_response(200)
-            self.send_header("Content-type", "text/html")
+            self.send_header("Content-type", "text/html; charset=utf-8")
             self.end_headers()
             self.wfile.write(bytes(export_webserver.config, "utf-8"))
             parsed_data = parse_qs(urlparse(self.path).query)
             logging.info(f"{parsed_data}")
         elif self.path.startswith('/json'):
             self.send_response(200)
-            self.send_header("Content-type", "application/json")
+            self.send_header("Content-type", "application/json; charset=utf-8")
             self.end_headers()
             self.wfile.write(bytes(export_webserver.json, "utf-8"))
         else:

--- a/SunGather/registers-sungrow.yaml
+++ b/SunGather/registers-sungrow.yaml
@@ -3,25 +3,33 @@ vendor: Sungrow
 registers:
   - read:
     - name: "protocol_number"
+      type: gauge
+      description: "Protocol Number"
       level: 2
       address: 4950
       datatype: "U32"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "protocol_version"
+      type: gauge
+      description: "Protocol Version"
       level: 2
       address: 4952
       datatype: "U32"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "arm_software_version"
+      type: gauge
+      description: "ARM Sorfware Version"
       level: 2
       address: 4954
       datatype: "U16"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "dsp_software_version"
+      type: gauge
+      description: "DSP Sorfware Version"
       level: 2
       address: 4969
       datatype: "U16"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "serial_number"
       level: 3
       address: 4990
@@ -193,6 +201,8 @@ registers:
           value: "SH6.0RT"
         - response: 0xE00
           value: "SH5.0RT"
+        - response: 0xE0C
+          value: "SH5.0RT-V112"
       # G2 Inverters
         - response: 0x122
           value: "SG3K-D"
@@ -215,12 +225,15 @@ registers:
           value: "SG9.0RS"
         - response: 0x2609
           value: "SG10RS"
-    - name: "nominal_active_power"   
+    - name: "nominal_active_power"  
+      type: gauge
+      description: "Nominal Active Power in kWh"
       level: 2
       address: 5001
       datatype: "U16"
       accuracy: 0.1
       unit: "kW"
+      description: "Nominal Output Power in kW"
     - name: "output_type"
       level: 2
       address: 5002
@@ -232,77 +245,85 @@ registers:
           value: "3P4L"
         - response: 2
           value: "3PSL"
-    - name: "daily_power_yields"    
+    - name: "daily_power_yields"   
+      type: counter
+      description: "Daily Power Yields in kWh"
       level: 0
       address: 5003
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-    - name: "total_power_yields"  
-      level: 1  
+    - name: "total_power_yields" 
+      type: counter
+      description: "Total Power Yields in kWh"
+      level: 1 
       address: 5004
       datatype: "U32"
       unit: "kWh"
-    - name: "total_running_time"  
-      level: 1  
+    - name: "total_running_time" 
+      level: 1 
       address: 5006
       datatype: "U32"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
       unit: "h"
     - name: "internal_temperature"
-      level: 1    
+      type: gauge
+      description: "Internal Temperature of the in Inverter in °C"
+      level: 1   
       address: 5008
       datatype: "S16"
       accuracy: 0.1
       unit: "°C"
     - name: "total_apparent_power"
-      level: 1    
+      level: 1   
+      type: gauge
+      description: "Total Apparent Power in VA"
       address: 5009
       datatype: "U32"
       models: ["SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG33K3J","SG36KTL-M","SG40KTL-M","SG50KTL","SG50KTL-M","SG60KTL","SG60KTL-M","SG60KU-M","SG80KTL","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG33CX","SG40CX","SG50CX","SG110CX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG25CX-SA","SG100CX","SG75CX","SG225HX"]
       unit: "VA"
-    - name: "mppt_1_voltage"    
+    - name: "mppt_1_voltage"   
       level: 2
       address: 5011
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
-    - name: "mppt_1_current" 
-      level: 2   
+    - name: "mppt_1_current"
+      level: 2  
       address: 5012
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
-    - name: "mppt_2_voltage" 
-      level: 2   
+    - name: "mppt_2_voltage"
+      level: 2  
       address: 5013
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
-      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "mppt_2_current"
-      level: 2    
+      level: 2   
       address: 5014
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
-      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "mppt_3_voltage"
-      level: 2    
+      level: 2   
       address: 5015
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG50KTL-M-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX"]
     - name: "mppt_3_current"
-      level: 2    
+      level: 2   
       address: 5016
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG50KTL-M-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG8K-D"]
     - name: "total_dc_power"
-      level: 2    
+      level: 2   
       address: 5017
       datatype: "U32" # Documentation says Unsigned, but seems to be returning Signed 32bit
       unit: "W"
@@ -313,55 +334,55 @@ registers:
       accuracy: 0.1
       unit: "V"
     - name: "phase_b_voltage"
-      level: 2    
+      level: 2   
       address: 5020
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
     - name: "phase_c_voltage"
-      level: 2    
+      level: 2   
       address: 5021
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
     - name: "phase_a_current"
-      level: 2    
+      level: 2   
       address: 5022
       datatype: "S16" # Documentation says Unsigned, but seems to be returning Signed 16bit
       accuracy: 0.1
       unit: "A"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-    - name: "phase_b_current" 
-      level: 2   
+    - name: "phase_b_current"
+      level: 2  
       address: 5023
       datatype: "S16" # Documentation says Unsigned, but seems to be returning Signed 16bit
       accuracy: 0.1
       unit: "A"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
     - name: "phase_c_current"
-      level: 2    
+      level: 2   
       address: 5024
       datatype: "S16" # Documentation says Unsigned, but seems to be returning Signed 16bit
       accuracy: 0.1
       unit: "A"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5025
 #     datatype: "U32"
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5027
 #     datatype: "U32"
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5029
 #     datatype: "U32"
     - name: "total_active_power"
-      level: 0    
+      level: 0   
       address: 5031
       datatype: "U32"
       unit: "W"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
     - name: "total_reactive_power"
-      level: 2    
+      level: 2   
       address: 5033
       datatype: "S32"
       unit: "Var"
@@ -371,12 +392,12 @@ registers:
       datatype: "S16"
       accuracy: 0.001
     - name: "grid_frequency"
-      level: 2    
+      level: 2   
       address: 5036
       datatype: "U16"
       accuracy: 0.1
       unit: "Hz"
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5037
 #     datatype: "U16"
     - name: "work_state_1"                # See Appendix 1
@@ -414,12 +435,12 @@ registers:
       address: 5039
       datatype: "U16"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
-    - name: "alarm_time_month" 
-      level: 3   
+    - name: "alarm_time_month"
+      level: 3  
       address: 5040
       datatype: "U16"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
-    - name: "alarm_time_day"  
+    - name: "alarm_time_day" 
       level: 3
       address: 5041
       datatype: "U16"
@@ -429,8 +450,8 @@ registers:
       address: 5042
       datatype: "U16"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
-    - name: "alarm_time_minute" 
-      level: 3   
+    - name: "alarm_time_minute"
+      level: 3  
       address: 5043
       datatype: "U16"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
@@ -442,9 +463,9 @@ registers:
     - name: "alarm_code_1"               # See Appendix 3
       level: 3
       address: 5045
-      datatype: "U16" 
+      datatype: "U16"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5046 - 5048
 #     datatype: "U16"
 #     models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
@@ -455,27 +476,27 @@ registers:
       accuracy: 0.1
       unit: "kVar"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5050 - 5070
 #     datatype: "U32"
-    - name: "array_insulation_resistance" 
-      level: 2   
+    - name: "array_insulation_resistance"
+      level: 2  
       address: 5071
       datatype: "U16"
       unit: "k-ohm"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5072
 #     datatype: "U16"
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5073 - 5076
-    - name: "active_power_regulation_setpoint"   
-      level: 2 
+    - name: "active_power_regulation_setpoint"  
+      level: 2
       address: 5077
       datatype: "U32"
       unit: "W"
-      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "reactive_power_regulation_setpoint"    
+      models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "reactive_power_regulation_setpoint"   
       level: 2
       address: 5079
       datatype: "S32"
@@ -515,7 +536,7 @@ registers:
         - response: 18
           value: "Total Fault Bit"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG3K-D","SG5K-D","SG8K-D"]
-    - name: "meter_power" 
+    - name: "meter_power"
       level: 1
       address: 5083
       datatype: "S32"
@@ -589,189 +610,189 @@ registers:
       accuracy: 0.1
       unit: "kWh"
       models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3K-D","SG5K-D","SG8K-D"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5105 - 5112
     - name: "daily_running_time"
       level: 1
       address: 5113
       datatype: "U16"
       unit: "min"
-    - name: "mppt_4_voltage"    
+    - name: "mppt_4_voltage"   
       level: 2
       address: 5115
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KU-M","SG80KTL-M","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_4_current"    
+    - name: "mppt_4_current"   
       level: 2
       address: 5116
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KU-M","SG80KTL-M","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_5_voltage" 
-      level: 2   
+    - name: "mppt_5_voltage"
+      level: 2  
       address: 5117
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_5_current"  
-      level: 2  
+    - name: "mppt_5_current" 
+      level: 2 
       address: 5118
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_6_voltage"   
-      level: 2 
+    - name: "mppt_6_voltage"  
+      level: 2
       address: 5119
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_6_current"   
-      level: 2 
+    - name: "mppt_6_current"  
+      level: 2
       address: 5120
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_7_voltage"    
+    - name: "mppt_7_voltage"   
       level: 2
       address: 5121
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_7_current"    
+    - name: "mppt_7_current"   
       level: 2
       address: 5122
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_8_voltage"    
+    - name: "mppt_8_voltage"   
       level: 2
       address: 5123
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_8_current"    
+    - name: "mppt_8_current"   
       level: 2
       address: 5124
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5125
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5126 - 5127
-    - name: "monthly_power_yields"    
+    - name: "monthly_power_yields"   
       level: 1
       address: 5128
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-    - name: "mppt_9_voltage"    
+    - name: "mppt_9_voltage"   
       level: 2
       address: 5130
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_9_current"    
+    - name: "mppt_9_current"   
       level: 2
       address: 5131
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "mppt_10_voltage"    
+    - name: "mppt_10_voltage"   
       level: 2
       address: 5132
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "mppt_10_current"    
+    - name: "mppt_10_current"   
       level: 2
       address: 5133
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "mppt_11_voltage"    
+    - name: "mppt_11_voltage"   
       level: 2
       address: 5134
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "mppt_11_current"    
+    - name: "mppt_11_current"   
       level: 2
       address: 5135
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "mppt_12_voltage"    
+    - name: "mppt_12_voltage"   
       level: 2
       address: 5136
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "mppt_12_current"    
+    - name: "mppt_12_current"   
       level: 2
       address: 5137
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5138 - 5139
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5140
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5141
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5142
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5143
-    - name: "total_power_yields"    
+    - name: "total_power_yields"   
       level: 1
       address: 5144
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
       models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG33CX","SG40CX","SG50CX","SG110CX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG25CX-SA","SG100CX","SG75CX","SG225HX","SG3K-D","SG5K-D","SG8K-D"]
-    - name: "negative_voltage_to_the_ground"   
-      level: 2 
+    - name: "negative_voltage_to_the_ground"  
+      level: 2
       address: 5146
       datatype: "S16"
       accuracy: 0.1
       unit: "V"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-    - name: "bus_voltage"    
+    - name: "bus_voltage"   
       level: 2
       address: 5147
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-    - name: "grid_frequency"    
+    - name: "grid_frequency"   
       level: 2
       address: 5148
       datatype: "U16"
       accuracy: 0.01
       unit: "Hz"
       models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG33CX","SG40CX","SG50CX","SG110CX","SG250HX","SG30CX","SG36CX-US","SG60CX-US","SG250HX-US","SG250HX-IN","SG25CX-SA","SG100CX","SG75CX","SG225HX","SG3K-D","SG5K-D","SG8K-D"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5149
 #     datatype: "U16"
 #     accuracy: 0.01
@@ -799,7 +820,7 @@ registers:
         - response: 434
           value: "PID overvoltage/overcurrent protection"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5152
 #     datatype: "U16"
     # Following 2 registers are not in the documentation, but other projects are using them
@@ -809,13 +830,13 @@ registers:
       datatype: "S32"
       unit: "W"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-    - name: "power_meter" 
-      level: 2   
+    - name: "power_meter"
+      level: 2  
       address: 5218
       datatype: "S32"
       unit: "W"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5153-7012
 ##### Residential Hybrid Inverters only START
     - name: "export_limit_min"
@@ -824,304 +845,304 @@ registers:
       datatype: "U16"
       accuracy: 10
       unit: "W"
-      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "export_limit_max"
       level: 2
       address: 5623
       datatype: "U16"
       accuracy: 10
       unit: "W"
-      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bdc_rated_power"
       level: 2
       address: 5628
       datatype: "U16"
       accuracy: 100
       unit: "W"
-      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bms_max_charging_current"
       level: 2
       address: 5635
       datatype: "U16"
       unit: "A"
-      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bms_max_discharging_current"
       level: 2
       address: 5636
       datatype: "U16"
       unit: "A"
-      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "pv_power_of_today"
       level: 1
       address: 6100
       datatype: "U16"
       unit: "W"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "daily_pv_energy_yields"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "daily_pv_energy_yields"   
       level: 1
       address: 6196
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "monthly_pv_energy_yields"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "monthly_pv_energy_yields"   
       level: 2
       address: 6227
       datatype: "U16"
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "yearly_pv_energy_yields"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "yearly_pv_energy_yields"   
       level: 2
       address: 6250
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "direct_power_consumption_today_pv"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "direct_power_consumption_today_pv"   
       level: 1
       address: 6290
       datatype: "U16"
       unit: "W"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "direct_power_consumption_pv"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "direct_power_consumption_pv"   
       level: 1
       address: 6386
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "direct_power_consumption_monthly_pv"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "direct_power_consumption_monthly_pv"   
       level: 2
       address: 6417
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "direct_power_consumption_yearly_pv"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "direct_power_consumption_yearly_pv"   
       level: 2
       address: 6429
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "export_power_from_pv_today"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "export_power_from_pv_today"   
       level: 1
       address: 6469
       datatype: "U16"
       unit: "W"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "export_power_from_pv"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "export_power_from_pv"   
       level: 1
       address: 6565
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "export_power_from_pv_monthly"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "export_power_from_pv_monthly"   
       level: 2
       address: 6596
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "export_power_from_pv_yearly"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "export_power_from_pv_yearly"   
       level: 2
       address: 6608
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "battery_charge_power_from_pv_today"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_charge_power_from_pv_today"   
       level: 1
       address: 6648
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "battery_charge_power_from_pv"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_charge_power_from_pv"   
       level: 1
       address: 6744
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "battery_charge_power_from_pv_monthly"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_charge_power_from_pv_monthly"   
       level: 2
       address: 6775
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "battery_charge_power_from_pv_yearly"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_charge_power_from_pv_yearly"   
       level: 2
       address: 6787
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
  ##### Residential Hybrid Inverters only END
-    - name: "string_1_current"    
+    - name: "string_1_current"   
       level: 2
       address: 7013
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-    - name: "string_2_current"    
+    - name: "string_2_current"   
       level: 2
       address: 7014
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-    - name: "string_3_current"    
+    - name: "string_3_current"   
       level: 2
       address: 7015
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT", ]
-    - name: "string_4_current"    
+    - name: "string_4_current"   
       level: 2
       address: 7016
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX", ]
-    - name: "string_5_current"    
+    - name: "string_5_current"   
       level: 2
       address: 7017
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX", ]
-    - name: "string_6_current"    
+    - name: "string_6_current"   
       level: 2
       address: 7018
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX", ]
-    - name: "string_7_current"    
+    - name: "string_7_current"   
       level: 2
       address: 7019
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
-    - name: "string_8_current"    
+    - name: "string_8_current"   
       level: 2
       address: 7020
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
-    - name: "string_9_current"    
+    - name: "string_9_current"   
       level: 2
       address: 7021
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KU","SG36KTL","SG36KU","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG33K3J","SG49K5J","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
-    - name: "string_10_current"    
+    - name: "string_10_current"   
       level: 2
       address: 7022
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG30KU","SG36KTL","SG36KU","SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
-    - name: "string_11_current"    
+    - name: "string_11_current"   
       level: 2
       address: 7023
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
-    - name: "string_12_current"    
+    - name: "string_12_current"   
       level: 2
       address: 7024
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG50KTL-M","SG60KTL-M","SG49K5J","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
-    - name: "string_13_current"    
+    - name: "string_13_current"   
       level: 2
       address: 7025
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG60KTL-M","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX", ]
-    - name: "string_14_current"    
+    - name: "string_14_current"   
       level: 2
       address: 7026
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG60KTL-M","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG30CX","SG33CX","SG36CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT", ]
-    - name: "string_15_current"    
+    - name: "string_15_current"   
       level: 2
       address: 7027
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG60KTL-M","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "string_16_current"    
+    - name: "string_16_current"   
       level: 2
       address: 7028
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG60KTL-M","SG80KTL","SG80KTL-20","SG60KU-M","SG80KTL-M","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "string_17_current"    
+    - name: "string_17_current"   
       level: 2
       address: 7029
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG80KTL","SG80KTL-20","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "string_18_current"    
+    - name: "string_18_current"   
       level: 2
       address: 7030
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG80KTL","SG80KTL-20","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG75CX"]
-    - name: "string_19_current"    
+    - name: "string_19_current"   
       level: 2
       address: 7031
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "string_20_current"    
+    - name: "string_20_current"   
       level: 2
       address: 7032
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "string_21_current"    
+    - name: "string_21_current"   
       level: 2
       address: 7033
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "string_22_current"    
+    - name: "string_22_current"   
       level: 2
       address: 7034
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "string_23_current"    
+    - name: "string_23_current"   
       level: 2
       address: 7035
       datatype: "U16"
       accuracy: 0.01
       unit: "A"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
-    - name: "string_24_current"    
+    - name: "string_24_current"   
       level: 2
       address: 7036
       datatype: "U16"
@@ -1129,7 +1150,7 @@ registers:
       unit: "A"
       models: ["SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN"]
   ##### Residential Hybrid Inverters only START
-    - name: "system_state"    
+    - name: "system_state"   
       level: 2
       address: 13000
       datatype: "U16"
@@ -1157,192 +1178,192 @@ registers:
         - response: 0x4000
           value: "EMS Run"
       default: "Unknown"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "running_state"
       level: 2
       address: 13001
       datatype: "U16"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "state_power_generated_from_pv"
       level: 2
       address: 13001
       datatype: "U16"
       mask: 1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "state_battery_charging"
       level: 2
       address: 13001
       datatype: "U16"
       mask: 2
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "state_battery_discharging"
       level: 2
       address: 13001
       datatype: "U16"
       mask: 4
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "state_load_active"
       level: 2
       address: 13001
       datatype: "U16"
       mask: 8
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "state_feed_into_grid"
       level: 2
       address: 13001
       datatype: "U16"
       mask: 16
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "state_import_from_grid"
       level: 2
       address: 13001
       datatype: "U16"
       mask: 32
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "state_power_generated_from_load"
       level: 2
       address: 13001
       datatype: "U16"
       mask: 128
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "daily_pv_generation"
       level: 2
       address: 13002
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "total_pv_generation"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "total_pv_generation"   
       level: 1
       address: 13003
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "daily_pv_export"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "daily_pv_export"   
       level: 1
       address: 13005
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "total_pv_export"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "total_pv_export"   
       level: 1
       address: 13006
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "load_power_hybrid"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "load_power_hybrid"   
       level: 1
       address: 13008
       datatype: "S32"
       unit: "W"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "export_power_hybrid"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "export_power_hybrid"   
       level: 1
       address: 13010
       datatype: "S32"
       unit: "W"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "daily_battery_charge_from_pv"
       level: 1
       address: 13012
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "total_battery_charge_from_pv"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "total_battery_charge_from_pv"   
       level: 1
       address: 13013
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "co2_reduction"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "co2_reduction"   
       level: 2
       address: 13015
       datatype: "U32"
       accuracy: 0.1
       unit: "kg"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "daily_direct_energy_consumption"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "daily_direct_energy_consumption"   
       level: 1
       address: 13017
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "total_direct_energy_consumption"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "total_direct_energy_consumption"   
       level: 1
       address: 13018
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"] 
-    - name: "battery_voltage"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_voltage"   
       level: 2
       address: 13020
       datatype: "U16"
       accuracy: 0.1
       unit: "V"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "battery_current"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_current"   
       level: 2
       address: 13021
       datatype: "U16"
       accuracy: 0.1
       unit: "A"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "battery_power"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_power"   
       level: 1
       address: 13022
       datatype: "S16"
       unit: "W"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "battery_level"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_level"   
       level: 1
       address: 13023
       datatype: "U16"
       accuracy: 0.1
       unit: "%"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "battery_state_of_healthy"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_state_of_healthy"   
       level: 2
       address: 13024
       datatype: "U16"
       accuracy: 0.1
       unit: "%"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "battery_temperature"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_temperature"   
       level: 2
       address: 13025
       datatype: "S16"
       accuracy: 0.1
       unit: "°C"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "daily_battery_discharge_energy"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "daily_battery_discharge_energy"   
       level: 2
       address: 13026
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "total_battery_discharge_energy"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "total_battery_discharge_energy"   
       level: 2
       address: 13027
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "self_consumption_of_day"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "self_consumption_of_day"   
       level: 1
       address: 13029
       datatype: "U16"
       accuracy: 0.1
       unit: "%"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "grid_state"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "grid_state"   
       level: 1
       address: 13030
       datatype: "U16"
@@ -1351,173 +1372,173 @@ registers:
           value: "Off-grid"
         - response: 0x55
           value: "On-grid"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "phase_a_current"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "phase_a_current"   
       level: 2
       address: 13031
       datatype: "S16"
       accuracy: 0.1
       unit: "A"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "phase_b_current"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "phase_b_current"   
       level: 2
       address: 13032
       datatype: "S16"
       accuracy: 0.1
       unit: "A"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "phase_c_current"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "phase_c_current"   
       level: 2
       address: 13033
       datatype: "S16"
       accuracy: 0.1
       unit: "A"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "total_active_power"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "total_active_power"   
       level: 0
       address: 13034
       datatype: "S32"
       unit: "W"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "daily_import_energy"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "daily_import_energy"   
       level: 1
       address: 13036
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "total_import_energy"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "total_import_energy"   
       level: 1
       address: 13037
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "battery_capacity"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "battery_capacity"   
       level: 1
       address: 13039
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
       models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30"]
-    - name: "daily_charge_energy"    
+    - name: "daily_charge_energy"   
       level: 2
       address: 13040
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "total_charge_energy"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "total_charge_energy"   
       level: 2
       address: 13041
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "drm_state"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "drm_state"   
       level: 2
       address: 13043
       datatype: "U16"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "daily_export_energy"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "daily_export_energy"   
       level: 1
       address: 13045
       datatype: "U16"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
-    - name: "total_export_energy"    
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
+    - name: "total_export_energy"   
       level: 2
       address: 13046
       datatype: "U32"
       accuracy: 0.1
       unit: "kWh"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "inverter_alarm"
       level: 3
       address: 13050
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "grid-side_fault"
       level: 3
       address: 13052
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "system_fault1"
       level: 3
       address: 13054
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "system_fault2"
       level: 3
       address: 13056
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "dc-side_fault"
       level: 3
       address: 13058
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "permanent_fault"
       level: 3
       address: 13060
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bdc-side_fault"
       level: 3
       address: 13062
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bdc-side_permanent_fault"
       level: 3
       address: 13064
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "battery_fault"
       level: 3
       address: 13066
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "battery_alarm"
       level: 3
       address: 13068
       datatype: "U32"
       accuracy: 0.1
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bms_alarm"
       level: 3
       address: 13070
       datatype: "U32"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bms_protection"
       level: 3
       address: 13072
       datatype: "U32"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bms_fault1"
       level: 3
       address: 13074
       datatype: "U32"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bms_fault2"
       level: 3
       address: 13076
       datatype: "U32"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bms_alarm2"
       level: 3
       address: 13078
       datatype: "U32"
-      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "bms_status"
       level: 3
       address: 13100
@@ -1683,7 +1704,7 @@ registers:
       datatype: "U16"
       accuracy: 0.1
       unit: "%"
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5009
 #     datatype: "U16"
 #     models: ["SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M"]
@@ -1753,7 +1774,7 @@ registers:
           value: "Enable"
         - response: 0x55
           value: "Disable"
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5021-5033
 #     datatype: "U16"
     - name: "night_svg_switch"
@@ -1787,7 +1808,7 @@ registers:
       datatype: "S16"
       accuracy: 0.1
       unit: "%"
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5038
     - name: "power_limitation_adjustment"
       level: 2
@@ -1831,11 +1852,11 @@ registers:
           value: "Enable"
         - response: 0x55
           value: "Disable"
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5043-5047
-#   - name: "Q(P) Curve"    
+#   - name: "Q(P) Curve"   
 #     address: 5048-5154
-#   - name: "Reserved"    
+#   - name: "Reserved"   
 #     address: 5155-5199
     - name: "start_charging_power"
       address: 13084
@@ -1843,14 +1864,14 @@ registers:
       accuracy: 10
       datatype: "U16"
       unit: "W"
-      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "start_discharging_power"
       address: 13085
       level: 2
       accuracy: 10
       datatype: "U16"
       unit: "W"
-      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "energy_meter_comm"
       address: 13086
       level: 2
@@ -1860,7 +1881,7 @@ registers:
           value: "Enabled"
         - response: 0x55
           value: "Disabled"
-      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "export_power_limitation"
       address: 13087
       level: 2
@@ -1870,13 +1891,13 @@ registers:
           value: "Enabled"
         - response: 0x55
           value: "Disabled"
-      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
     - name: "soc_reserve"
       address: 13100
       level: 2
       datatype: "U16"
       unit: "%"
-      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+      models: ["SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]
 scan: # these have to be 1 less than the first register
   - read:
     - start: 4949
@@ -1922,4 +1943,4 @@ scan: # these have to be 1 less than the first register
       range: 100
 # Models Supported:
 # PV      ["SG30KTL","SG10KTL","SG12KTL","SG15KTL","SG20KTL","SG30KU","SG36KTL","SG36KU","SG40KTL","SG40KTL-M","SG50KTL-M","SG60KTL-M","SG60KU","SG30KTL-M","SG30KTL-M-V31","SG33KTL-M","SG36KTL-M","SG33K3J","SG49K5J","SG34KJ","LP_P34KSG","SG50KTL-M-20","SG60KTL","SG80KTL","SG80KTL-20","SG60KU-M","SG5KTL-MT","SG6KTL-MT","SG8KTL-M","SG10KTL-M","SG10KTL-MT","SG12KTL-M","SG15KTL-M","SG17KTL-M","SG20KTL-M","SG80KTL-M","SG111HV","SG125HV","SG125HV-20","SG30CX","SG33CX","SG36CX-US","SG40CX","SG50CX","SG60CX-US","SG110CX","SG250HX","SG250HX-US","SG100CX","SG100CX-JP","SG250HX-IN","SG25CX-SA","SG75CX","SG3.0RT","SG4.0RT","SG5.0RT","SG4.0RS","SG5.0RS","SG6.0RT","SG7.0RT","SG8.0RT","SG8.0RS","SG10RT","SG12RT","SG15RT","SG17RT","SG20RT"]
-# Hybrid  ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT"]
+# Hybrid  ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH8.0RT","SH6.0RT","SH5.0RT", "SH5.0RT-V112"]


### PR DESCRIPTION
some values (i.e. non numerical) must not be in the produced metrics.

All metrics may have an optional `# HELP $description` line and should have a `# TYPE $metric_name $type` line.

`address` and `unit` tags have been removed as they give no information you cannot get from the "HELP" lines. They have been replaced with `model` and `serial` tags to allow multiple inverters in the same prometheus instance.

Other fixes:
* add `charset=utf-8` to webserver Content-Type headers.
* add `SH5.0RT-V112` that registers as 0xE0C
* add description and type to registers-sungrow.yaml

depends on https://github.com/bohdan-s/SungrowClient/pull/4