### PR TITLE
Catch exceptions when scraping the inverter

### DIFF
--- a/SunGather/sungather.py
+++ b/SunGather/sungather.py
@@ -151,7 +151,11 @@ def main():
         inverter.checkConnection()
 
         # Scrape the inverter
-        success = inverter.scrape()
+        try:
+            success = inverter.scrape()
+        except Exception as e:
+            logging.exception("Failed to scrape: %s", e)
+            success = False
 
         if(success):
             for export in exports:


### PR DESCRIPTION
The inverter can sometimes raise exceptions which causes the code to crash out completely. Catch them, log them, and continue the loop.

https://github.com/bohdan-s/SunGather/issues/137