### PR TITLE
Update to paho-mqtt v2.0.0

### DIFF
--- a/SunGather/exports/mqtt.py
+++ b/SunGather/exports/mqtt.py
@@ -33,7 +33,7 @@ class export_mqtt(object):
             logging.info(f"MQTT: Host config is required")
             return False
         client_id = self.mqtt_config['client_id']
-        self.mqtt_client = mqtt.Client(client_id)
+        self.mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id)
         self.mqtt_client.on_connect = self.on_connect
         self.mqtt_client.on_disconnect = self.on_disconnect
         self.mqtt_client.on_publish = self.on_publish
@@ -57,13 +57,13 @@ class export_mqtt(object):
     
         return True
 
-    def on_connect(self, client, userdata, flags, rc):
+    def on_connect(self, client, userdata, flags, reason_code, properties):
         logging.info(f"MQTT: Connected to {client._host}:{client._port}")
 
-    def on_disconnect(self, client, userdata, rc):
-        logging.info(f"MQTT: Server Disconnected code: {rc}")
+    def on_disconnect(self, client, userdata, flags, reason_code, properties):
+        logging.info(f"MQTT: Server Disconnected code: {reason_code}")
     
-    def on_publish(self, client, userdata, mid):
+    def on_publish(self, client, userdata, mid, reason_codes, properties):
         try:
             self.mqtt_queue.remove(mid)
         except Exception as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML>=6.0 
 requests>=2.26.0 
-paho-mqtt>=1.5.1
+paho-mqtt>=2.0.0
 SungrowClient>=0.1.0
 influxdb-client>=1.24.0


### PR DESCRIPTION
Made minor changes to export/mqtt.py and requirements.txt to ensure SunGather will work with paho-mqtt v2.0.0.