### PR TITLE
Rename Device for Home Assistant

### DIFF
--- a/SunGather/config-example.yaml
+++ b/SunGather/config-example.yaml
@@ -67,7 +67,7 @@ exports:
     # password:                             # [Optional] Password is MQTT server requires it
     # client_id:                            # [Optional] Client id for mqtt connection. Defaults to Serial Number.
     homeassistant: True
-    # ha_device_name: "new PV"   # [Optional] This is the Name shown in Home Assistant
+    # ha_device_name: "Sungrow new PV"      # [Optional] This is the Name shown in Home Assistant
     ha_sensors:
       - name: "Daily Generation"
         sensor_type: sensor

--- a/SunGather/config-example.yaml
+++ b/SunGather/config-example.yaml
@@ -67,6 +67,7 @@ exports:
     # password:                             # [Optional] Password is MQTT server requires it
     # client_id:                            # [Optional] Client id for mqtt connection. Defaults to Serial Number.
     homeassistant: True
+    # ha_device_name: "new PV"   # [Optional] This is the Name shown in Home Assistant
     ha_sensors:
       - name: "Daily Generation"
         sensor_type: sensor

--- a/SunGather/exports/mqtt.py
+++ b/SunGather/exports/mqtt.py
@@ -23,7 +23,8 @@ class export_mqtt(object):
             'topic': config.get('topic', f"SunGather/{self.serial_number}"),
             'username': config.get('username', None),
             'password': config.get('password',None),
-            'homeassistant': config.get('homeassistant',False)
+            'homeassistant': config.get('homeassistant',False),
+            'ha_device_name': config.get('ha_device_name',self.model)
         }
 
         self.ha_sensors = [{}]
@@ -93,7 +94,7 @@ class export_mqtt(object):
 
         if self.mqtt_config['homeassistant'] and not self.ha_discovery_published:
             # Build Device, this will be the same for every message
-            ha_device = { "name":f"Sungrow {self.model}", "manufacturer":"Sungrow", "model":self.model, "identifiers":self.serial_number, "via_device": "SunGather", "connections":[["address", inverter.getHost() ]]}
+            ha_device = { "name":f"{self.mqtt_config['ha_device_name']}", "manufacturer":"Sungrow", "model":self.model, "identifiers":self.serial_number, "via_device": "SunGather", "connections":[["address", inverter.getHost() ]]}
 
             for ha_sensor in self.ha_sensors:
                 config_msg = {}


### PR DESCRIPTION
Be able to rename the device name for Home Assistant connection to be able to have multiple inverters.

This change makes it possible to link several inverters of the same model series with Home Assistant. Several Docker containers from SunGather are used simultaneously and the “device name” for Home Assistant can be freely selected. This means that there is no longer any overlapping of devices in Home Assistant.

If “ha_device_name” is not used, everything remains the same.
Otherwise, this is used instead of “Sungrow {self.model}” for the name.