### PR TITLE
Update registers-sungrow.yaml

### DIFF
--- a/SunGather/registers-sungrow.yaml
+++ b/SunGather/registers-sungrow.yaml
@@ -1342,7 +1342,7 @@ registers:
     - name: "battery_current"    
       level: 2
       address: 13021
-      datatype: "U16"
+      datatype: "S16"
       accuracy: 0.1
       unit: "A"
       models: ["SH5K-20","SH3K6","SH4K6","SH5K-V13","SH5K-30","SH3K6-30","SH4K6-30","SH5.0RS","SH3.6RS","SH4.6RS","SH6.0RS","SH10RT","SH10RT-V112","SH10RT-20","SH8.0RT","SH6.0RT","SH5.0RT","SH5.0RT-V112"]


### PR DESCRIPTION
Update registers-sungrow.yaml
U16 reports very large Amps when battery is charging:
- with U16 datatype, result is | 13021   | battery_current                     | 6542.0 A 
- with S16 datatype, result reflects the correct value form web interface of | 13021   | battery_current                     | -12.1 A