### PR TITLE
Fix MQTT creating unnamed device in Home Assistant

### DIFF
--- a/SunGather/exports/mqtt.py
+++ b/SunGather/exports/mqtt.py
@@ -93,7 +93,7 @@ class export_mqtt(object):
 
         if self.mqtt_config['homeassistant'] and not self.ha_discovery_published:
             # Build Device, this will be the same for every message
-            ha_device = { "name":f"Sungrow {self.model}", "manufacturer":"Sungrow", "model":self.model, "identifiers":self.serial_number, "via_device": "SunGather", "connections":[["address", inverter.getHost() ]]}
+            ha_device = { "name":f"Sungrow {self.model}", "manufacturer":"Sungrow", "model":self.model, "identifiers":self.serial_number, "connections":[["address", inverter.getHost() ]]}
 
             for ha_sensor in self.ha_sensors:
                 config_msg = {}


### PR DESCRIPTION
## Summary
- Removes `via_device: "SunGather"` from Home Assistant MQTT discovery messages
- This field referenced a non-existent device, causing HA to create an empty "Unnamed device"
- The inverter device now appears standalone without a phantom parent device

## Background
The `via_device` field in HA discovery is meant to link devices in a hierarchy (e.g., sensors through a hub). However, no "SunGather" device was ever registered, so HA created an empty placeholder.

## Test plan
- [ ] Enable MQTT with `homeassistant: true`
- [ ] Check MQTT integration in Home Assistant
- [ ] Verify only the inverter device appears (no "Unnamed device")