### PR TITLE
Fix PVOutput 10-minute gaps by using clock-aligned upload intervals

### DIFF
--- a/SunGather/exports/pvoutput.py
+++ b/SunGather/exports/pvoutput.py
@@ -63,8 +63,7 @@ class export_pvoutput(object):
         self.collected_data = {}
         self.batch_data = []
         self.batch_count = 0
-        self.last_run = 0
-        self.last_publish = 0
+        self.last_uploaded_interval = 0
         
         for parameter in config.get('parameters'):
             if not inverter.validateRegister(parameter['register']):
@@ -151,8 +150,9 @@ class export_pvoutput(object):
 
     def publish(self, inverter):
         if self.collect_data(inverter):
-            # Process data points every status_interval
-            if((time.time() - self.last_publish) >= (self.status_interval * 60)):
+            # Process data points every status_interval (clock-aligned)
+            current_interval = int(time.time() // (self.status_interval * 60))
+            if current_interval > self.last_uploaded_interval:
                 any_data = False
                 if inverter.validateLatestScrape('timestamp'):
                     now = datetime.datetime.strptime(inverter.getRegisterValue('timestamp'), "%Y-%m-%d %H:%M:%S")
@@ -213,7 +213,7 @@ class export_pvoutput(object):
                             logging.error("PVOutput: Request; " + self.url_addbatchstatus + ", " + str(self.headers) + " : " + str(payload))
                         else:
                             self.batch_data = []
-                            self.last_publish = time.time()
+                            self.last_uploaded_interval = current_interval
                             logging.info("PVOutput: Data uploaded")
                     except Exception as err:
                         logging.error(f"PVOutput: Failed to Upload")
@@ -221,6 +221,5 @@ class export_pvoutput(object):
                 else:
                     logging.info("PVOutput: Data added to next batch upload")
             else:
-                logging.info(f"PVOutput: Data logged, next upload in {int(((self.status_interval) * 60) - (time.time() - self.last_publish))} secs")
-
-            self.last_run = time.time()
+                next_interval_time = (self.last_uploaded_interval + 1) * self.status_interval * 60
+                logging.info(f"PVOutput: Data logged, next upload in {int(next_interval_time - time.time())} secs")


### PR DESCRIPTION
## Summary
- Fixes intermittent 10-minute gaps appearing on PVOutput intraday data approximately every hour
- Changes from elapsed-time tracking to interval-number tracking for upload timing

## Problem
The previous code used `time.time() - last_publish >= interval` which caused uploads every ~5:30 instead of 5:00 due to processing time being added after each upload. This resulted in 11 uploads/hour instead of 12, causing one 5-minute slot to be skipped each hour.

**Log evidence:**
```
00:02:36 → 00:08:06 (5:30)
00:08:06 → 00:13:36 (5:30)
00:13:36 → 00:19:06 (5:30)
```

## Solution
Use interval-number tracking aligned to clock boundaries:
```python
current_interval = int(time.time() // (self.status_interval * 60))
if current_interval > self.last_uploaded_interval:
```

This ensures uploads align to clock boundaries (e.g., :00, :05, :10) with no drift.

## Test plan
- [x] Verified uploads now happen at exact 5-minute intervals (19:40:16 → 19:45:16 → 19:50:16)
- [x] Confirmed countdown timer decreases correctly
- [ ] Monitor PVOutput intraday page for 24+ hours to confirm no gaps